### PR TITLE
created develop branched and made corrections to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone --depth 1 -b v0.8.0 https://github.com/krakenrf/librtlsdr /tmp/lib
     ldconfig
 
 WORKDIR /root/auto-sdr/
-COPY . .
+RUN git clone https://github.com/shajen/rtl-sdr-scanner-cpp ./
 RUN cmake -B /root/auto-sdr/build -DCMAKE_BUILD_TYPE=Release /root/auto-sdr && \
     cmake --build /root/auto-sdr/build -j$(nproc) && \
     strip /root/auto-sdr/build/auto_sdr && \


### PR DESCRIPTION
Running [`COPY ..`](https://github.com/anoduck/rtl-sdr-scanner-cpp/blob/7894112507e271a8c582078b68e704353e091d05/Dockerfile#L14) caused an error during the build process with cmake cache, as the working directory `/root/autosdr/build` differed from the directory the repository was originally cloned into `/home/user/rtl-sdr-scanner-cpp`. To mitigate this error, rather than copying local resources into the docker container, the resources were cloned into the container with a fresh copy.

Below is the error output encountered:

```bash
CMake Error: The current CMakeCache.txt directory /root/auto-sdr/build/CMakeCache.txt is different than the directory /home/user/rtl-sdr-scanner-cpp/build where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt
CMake Error: The source "/root/auto-sdr/CMakeLists.txt" does not match the source "/home/user/rtl-sdr-scanner-cpp/CMakeLists.txt" used to generate cache.  Re-run cmake with a different source directory.
Error: building at STEP "RUN cmake -B /root/auto-sdr/build -DCMAKE_BUILD_TYPE=Release /root/auto-sdr &&     cmake --build /root/auto-sdr/build -j$(nproc) &&     strip /root/auto-sdr/build/auto_sdr &&     strip /root/auto-sdr/build/auto_sdr_test": while running runtime: exit status 1
```


Corrected error of differencing cmakecache directories. Implemented `RUN git clone ...` rather than a simple `COPY . .`. 