### PR TITLE
Fixed rtlsdr_get_index_by_serial(1) issue.

### DIFF
--- a/sources/radio/sdr_device_reader.cpp
+++ b/sources/radio/sdr_device_reader.cpp
@@ -35,7 +35,7 @@ std::vector<nlohmann::json> getGains(SoapySDR::Device* sdr) {
 }
 
 void SdrDeviceReader::updateSoapyDevice(nlohmann::json& json, const SoapySDR::Kwargs args) {
-  const auto serial = removeZerosFromBegging(args.at("serial"));
+  const auto serial = args.at("serial");
   const auto driver = args.at("driver");
   Logger::info(LABEL, "update device, driver: {}, serial: {}", colored(GREEN, "{}", driver), colored(GREEN, "{}", serial));
 
@@ -57,7 +57,7 @@ void SdrDeviceReader::updateSoapyDevice(nlohmann::json& json, const SoapySDR::Kw
 }
 
 void SdrDeviceReader::createSoapyDevices(nlohmann::json& json, const SoapySDR::Kwargs args) {
-  const auto serial = removeZerosFromBegging(args.at("serial"));
+  const auto serial = args.at("serial");
   const auto driver = args.at("driver");
   Logger::info(LABEL, "creating device, driver: {}, serial: {}", colored(GREEN, "{}", driver), colored(GREEN, "{}", serial));
 
@@ -111,8 +111,8 @@ void SdrDeviceReader::scanSoapyDevices(nlohmann::json& json) {
   for (uint32_t i = 0; i < results.size(); ++i) {
     try {
       auto& devices = json.at("devices");
-      const auto serial = removeZerosFromBegging(results[i].at("serial"));
-      const auto f = [serial](nlohmann::json& device) { return removeZerosFromBegging(device.at("serial").get<std::string>()) == serial; };
+      const auto serial = results[i].at("serial");
+      const auto f = [serial](nlohmann::json& device) { return device.at("serial").get<std::string>() == serial; };
       const auto it = std::find_if(devices.begin(), devices.end(), f);
       if (it != devices.end()) {
         updateSoapyDevice(*it, results[i]);
@@ -138,7 +138,7 @@ Device SdrDeviceReader::readDevice(const nlohmann::json& json) {
     const auto value = item.at("value").get<float>();
     device.m_gains.emplace_back(key, value);
   }
-  device.m_serial = removeZerosFromBegging(json.at("serial").get<std::string>());
+  device.m_serial = json.at("serial").get<std::string>();
   device.m_sampleRate = json.at("sample_rate").get<Frequency>();
   for (const auto& item : json.at("ranges")) {
     const auto start = item.at("start").get<Frequency>();


### PR DESCRIPTION
Hello shajen,

This pull request is to fix the [following issue](https://github.com/shajen/sdr-hub/issues/3) presented in the sdr-hub project that pulls from this one. In short, when using an rtlsdr, the sdr_device_reader module read the serial number without leading zeros (Ie: serial number "000001" was read as "1"). This tripped up soapysdr which threw: rtlsdr_get_index_by_serial(1) - -3 error when creating the source object as it expected a full serial number string.

The fix consists on removing all calls to "removeZerosFromBegging" on rtl-sdr-scanner-cpp/sources/radio/sdr_device_reader.cpp. So far, I have tested this fix on my setup using a rtlsdr blog v4 and it's working beautifully, nothing has broken yet. Another user reported the same error and implemented the fix to the same result. I suspect the function had a purpose, but things are working as intended without it at least with rtlsdr dongles, sadly I don't have the means to test out more soapysdr compatible hardware.

Either way, thanks for the good work on this software. I'll be on the lookout for any feeback. Cheers,

gsparrow9