### PR TITLE
Added check to ignore specific indices in signal processing.(#134)

### DIFF
--- a/sources/radio/blocks/transmission.cpp
+++ b/sources/radio/blocks/transmission.cpp
@@ -84,6 +84,9 @@ void Transmission::addSignals(const float* avgPower, const float* rawPower, cons
   for (const auto& index : indexes) {
     if (!containsWithMargin(m_signals, index, m_groupSize)) {
       const auto bestIndex = getBestIndex(index);
+      if (isIndexIgnored(bestIndex)) {
+        continue;
+      }
       const auto bestTunedFrequency = getTunedFrequency(m_indexToFrequency(bestIndex), m_config.recordingTuningStep());
       Logger::info(
           LABEL,


### PR DESCRIPTION
Ignore filtering previously applied only to the initial candidate bin. After getBestIndex() refinement, the signal could still land in an ignored range and trigger recording. Add isIndexIgnored(bestIndex) before inserting into m_signals.
Fixes #134